### PR TITLE
Add error boundary

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,6 +15,7 @@ import { LocksContextProvider } from './contexts/LocksContext'
 import { DelegateContextProvider } from '@/contexts/DelegatesContext'
 import { NetworkContextProvider } from './contexts/NetworkContext'
 import { THEME_KEY } from './lib/constants'
+import ErrorBoundary from './components/ErrorBoundary'
 
 const App = () => {
   const [settings] = useLocalStorage(THEME_KEY, {
@@ -22,7 +23,7 @@ const App = () => {
   })
 
   return (
-    <>
+    <ErrorBoundary>
       <ThemeProvider defaultTheme={settings?.themeMode as Theme}>
         <ReDotProvider config={config}>
           <ReDotChainProvider chainId="polkadot">
@@ -49,7 +50,7 @@ const App = () => {
         </ReDotProvider>
       </ThemeProvider>
       <Toaster />
-    </>
+    </ErrorBoundary>
   )
 }
 

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -1,0 +1,50 @@
+import { Component, ErrorInfo, ReactNode } from 'react'
+
+interface Props {
+  children: ReactNode
+}
+
+interface State {
+  hasError: boolean
+  error?: Error
+}
+
+class ErrorBoundary extends Component<Props, State> {
+  public state: State = {
+    hasError: false,
+  }
+
+  public static getDerivedStateFromError(error: Error): State {
+    // Update state so the next render will show the fallback UI.
+    return { hasError: true, error }
+  }
+
+  public componentDidCatch(error: Error, errorInfo: ErrorInfo) {
+    console.error('Uncaught error:', error, errorInfo)
+  }
+
+  public render() {
+    if (this.state.hasError) {
+      return (
+        <div className="p-4">
+          <h1>
+            An error occurred, please report it{' '}
+            <a
+              className="cursor-pointer font-bold text-pink-500 underline hover:text-pink-700"
+              href="https://github.com/delegit-xyz/dashboard/issues/new"
+              target="_blank"
+            >
+              on Delegit Github repo
+            </a>
+          </h1>
+          <pre>{this.state.error?.message}</pre>
+          <pre>{this.state.error?.stack}</pre>
+        </div>
+      )
+    }
+
+    return this.props.children
+  }
+}
+
+export default ErrorBoundary


### PR DESCRIPTION
Show a "nice" error when things go wrong, with an action item to report it.
To manually trigger it you can follow https://dev.to/ninariccimarie/how-to-trigger-react-error-boundary-with-react-developer-tools-1ccg

![image](https://github.com/user-attachments/assets/c5ce9375-cbb1-4ee2-acad-cbfd293df500)
