### PR TITLE
Add info on delegation lock

### DIFF
--- a/src/components/Alert.tsx
+++ b/src/components/Alert.tsx
@@ -1,0 +1,16 @@
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
+import { AlertCircle } from 'lucide-react'
+
+interface Props {
+  title: string
+  message: string
+  variant?: 'default' | 'destructive' | null
+}
+
+export const AlertNote = ({ title, message, variant = 'default' }: Props) => (
+  <Alert variant={variant}>
+    <AlertCircle className="h-4 w-4" />
+    <AlertTitle>{title}</AlertTitle>
+    <AlertDescription>{message}</AlertDescription>
+  </Alert>
+)

--- a/src/contexts/LocksContext.tsx
+++ b/src/contexts/LocksContext.tsx
@@ -21,7 +21,10 @@ import {
   KsmQueries,
   VotingConviction,
 } from '@polkadot-api/descriptors'
-import { convertMiliseconds } from '@/lib/convertMiliseconds'
+import {
+  convertMiliseconds,
+  displayRemainingTime,
+} from '@/lib/convertMiliseconds'
 
 // eslint-disable-next-line react-refresh/only-export-components
 export enum LockType {
@@ -382,7 +385,7 @@ const LocksContextProvider = ({ children }: LocksContextProps) => {
 
         return {
           multiplier: Number(conviction.replace('Locked', '').replace('x', '')),
-          display: `${convertMiliseconds(Number(convictionLocksMap[conviction])).d} days lock`,
+          display: `${displayRemainingTime(convertMiliseconds(Number(convictionLocksMap[conviction])))} lock`,
         }
       } else {
         if (conviction === 0) {
@@ -391,7 +394,7 @@ const LocksContextProvider = ({ children }: LocksContextProps) => {
         const key = `Locked${conviction}x`
         return {
           multiplier: conviction,
-          display: `${convertMiliseconds(Number(convictionLocksMap[key])).d} days lock`,
+          display: `${displayRemainingTime(convertMiliseconds(Number(convictionLocksMap[key])))} lock`,
         }
       }
     },

--- a/src/lib/convertMiliseconds.ts
+++ b/src/lib/convertMiliseconds.ts
@@ -34,14 +34,24 @@ export const displayRemainingTime = ({
   s,
 }: DaysHoursMinutesSeconds) => {
   if (d > 0) {
+    if (h === 0) {
+      return `${d} days`
+    }
     return `${d} days ${h}h`
   }
 
   if (d === 0 && h > 0) {
+    if (m === 0) {
+      return `${h}h`
+    }
+
     return `${h}h ${m}min`
   }
 
   if (d === 0 && h === 0 && m > 0) {
+    if (s === 0) {
+      return `${m}min`
+    }
     return `${m}min ${s}s`
   }
 

--- a/src/pages/Delegate/index.tsx
+++ b/src/pages/Delegate/index.tsx
@@ -9,25 +9,12 @@ import { useAccounts } from '@/contexts/AccountsContext'
 import { Slider } from '@/components/ui/slider'
 import { Link, useParams } from 'react-router-dom'
 
-import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
-import { AlertCircle, ArrowLeft } from 'lucide-react'
+import { ArrowLeft } from 'lucide-react'
 import { msgs } from '@/lib/constants'
 import { evalUnits, planckToUnit } from '@polkadot-ui/utils'
 import { useLocks } from '@/contexts/LocksContext'
 import { useGetDelegateTx } from '@/hooks/useGetDelegateTx'
-
-type AlertProps = {
-  title: string
-  message: string
-  variant?: 'default' | 'destructive' | null | undefined
-}
-const AlertNote = ({ title, message, variant = 'default' }: AlertProps) => (
-  <Alert variant={variant}>
-    <AlertCircle className="h-4 w-4" />
-    <AlertTitle>{title}</AlertTitle>
-    <AlertDescription>{message}</AlertDescription>
-  </Alert>
-)
+import { AlertNote } from '@/components/Alert'
 
 export const Delegate = () => {
   const { api, assetInfo } = useNetwork()
@@ -45,15 +32,25 @@ export const Delegate = () => {
   const [conviction, setConviction] = useState<VotingConviction>(
     VotingConviction.None,
   )
-  const [convictionNo, setConvictionNo] = useState(0)
+  const [convictionNo, setConvictionNo] = useState(1)
   const { selectedAccount } = useAccounts()
   const getDelegateTx = useGetDelegateTx()
 
-  const convictionDisplay = useMemo(() => {
-    const { display, multiplier } = getConvictionLockTimeDisplay(convictionNo)
+  const { display: convictionTimeDisplay, multiplier: convictionMultiplier } =
+    getConvictionLockTimeDisplay(convictionNo)
 
-    return `x${Number(multiplier)} | ${display}`
-  }, [convictionNo, getConvictionLockTimeDisplay])
+  const voteAmount = useMemo(() => {
+    const bnAmount =
+      convictionMultiplier === 0.1
+        ? amount / 10n
+        : amount * BigInt(convictionMultiplier)
+
+    return planckToUnit(bnAmount, assetInfo.precision).toLocaleString('en')
+  }, [amount, assetInfo.precision, convictionMultiplier])
+
+  const convictionDisplay = useMemo(() => {
+    return `x${Number(convictionMultiplier)} | ${convictionTimeDisplay}`
+  }, [convictionTimeDisplay, convictionMultiplier])
 
   const amountErrorDisplay = useMemo(() => {
     if (!isAmountDirty) return ''
@@ -121,18 +118,14 @@ export const Delegate = () => {
         <AlertNote
           title={msgs.api.title}
           message={msgs.api.message}
-          variant={
-            msgs.api.variant as 'default' | 'destructive' | null | undefined
-          }
+          variant={msgs.api.variant}
         />
       )}
       {!selectedAccount && (
         <AlertNote
           title={msgs.account.title}
           message={msgs.account.message}
-          variant={
-            msgs.account.variant as 'default' | 'destructive' | null | undefined
-          }
+          variant={msgs.account.variant}
         />
       )}
 
@@ -174,15 +167,16 @@ export const Delegate = () => {
           )
         }}
       />
+      <AlertNote
+        title={'Note'}
+        message={`The ${convictionTimeDisplay} will start when you undelegate`}
+        variant={'default'}
+      />
       <Button
         onClick={onSign}
         disabled={amount === 0n || !api || !selectedAccount}
       >
-        Delegate{' '}
-        {amount !== null &&
-          planckToUnit(amount, assetInfo.precision).toLocaleString('en')}{' '}
-        {assetInfo.symbol} with {convictionNo == 0 ? 0.1 : convictionNo}x
-        conviction
+        Delegate with {voteAmount} {assetInfo.symbol} votes
       </Button>
     </main>
   )


### PR DESCRIPTION
closes #29 
This includes a bunch of enhancements
- the lock < 1 day are nicely displayed
- we now show the amount of votes with the conviction
- x1 is now the default

![image](https://github.com/user-attachments/assets/cbd4967e-9ed8-40e0-b6d1-29ada5bfce55)

---

Submission checklist:

#### Layout

- [x] Change inspected in the mobile web ui
- [x] Change inspected in dark mode
