### PR TITLE
Switch to node  22

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 21
+          node-version: 22
           cache: 'pnpm'
       - run: pnpm install
       - run: pnpm build

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 21
+          node-version: 22
           cache: 'pnpm'
       - run: pnpm install
       - run: pnpm run lint


### PR DESCRIPTION
v21 is end of life already and CI failed a couple times bc it's too slow to download. Switching to the current 22. See https://nodejs.org/en/about/previous-releases