### PR TITLE
Fix account selection overflow

### DIFF
--- a/src/header.tsx
+++ b/src/header.tsx
@@ -187,7 +187,7 @@ export const Header = () => {
                     <ChevronDown className="ml-2 h-4 w-4" />
                   </Button>
                 </DropdownMenuTrigger>
-                <DropdownMenuContent>
+                <DropdownMenuContent className="max-h-[calc(100vh-5rem)] overflow-auto">
                   {accounts.map((account, index) => (
                     <>
                       <DropdownMenuItem


### PR DESCRIPTION
closes #161

works with any display size and account list size
![image](https://github.com/user-attachments/assets/616713cd-9478-4af8-87fe-18584d141503)

---

Submission checklist:

#### Layout

- [x] Change inspected in the mobile web ui
- [x] Change inspected in dark mode
